### PR TITLE
Fix middleware export name

### DIFF
--- a/api-gateway/src/middleware/auth.middleware.js
+++ b/api-gateway/src/middleware/auth.middleware.js
@@ -2,7 +2,7 @@ const jwt = require('jsonwebtoken');
 const config = require('../config/app.config');
 const logger = require('../utils/logger');
 
-const authMiddleware = (req, res, next) => {
+const authenticateToken = (req, res, next) => {
   try {
     const authHeader = req.headers.authorization;
     
@@ -27,4 +27,4 @@ const authMiddleware = (req, res, next) => {
   }
 };
 
-module.exports = { authMiddleware };
+module.exports = { authenticateToken };


### PR DESCRIPTION
## Summary
- fix misnamed export in API gateway auth middleware

## Testing
- `npm test` in api-gateway *(fails: jest not found)*
- `npm test` in auth-service *(fails: jest not found)*
- `npm test` in calendar-service *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6849278fc6b48324b8d203088961ceef